### PR TITLE
Fix Framed Blocks conflict when other mods are present

### DIFF
--- a/src/main/java/voltaic/common/block/BlockCustomGlass.java
+++ b/src/main/java/voltaic/common/block/BlockCustomGlass.java
@@ -13,11 +13,12 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockCustomGlass extends Block {
 
     public BlockCustomGlass(float hardness, float resistance) {
-        super(Blocks.GLASS.properties().requiresCorrectToolForDrops().strength(hardness, resistance).isRedstoneConductor((x, y, z) -> false).noOcclusion());
+        super(VoltaicMaterials.glass().requiresCorrectToolForDrops().strength(hardness, resistance).isRedstoneConductor((x, y, z) -> false).noOcclusion());
     }
 
     @Override

--- a/src/main/java/voltaic/common/block/BlockMultiSubnode.java
+++ b/src/main/java/voltaic/common/block/BlockMultiSubnode.java
@@ -22,13 +22,14 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import voltaic.api.multiblock.subnodebased.TileMultiSubnode;
 import voltaic.api.multiblock.subnodebased.child.IMultiblockChildBlock;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.block.GenericEntityBlock;
 import voltaic.prefab.tile.GenericTile;
 
 public class BlockMultiSubnode extends GenericEntityBlock implements IMultiblockChildBlock {
 
     public BlockMultiSubnode() {
-        super(Blocks.GLASS.properties().strength(3.5F).sound(SoundType.METAL).isRedstoneConductor((a, b, c) -> false).noOcclusion());
+        super(VoltaicMaterials.glass().strength(3.5F).sound(SoundType.METAL).isRedstoneConductor((a, b, c) -> false).noOcclusion());
     }
 
     @Override

--- a/src/main/java/voltaic/prefab/block/GenericMachineBlock.java
+++ b/src/main/java/voltaic/prefab/block/GenericMachineBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import voltaic.common.block.states.VoltaicBlockStates;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.common.block.voxelshapes.VoxelShapeProvider;
 
 public class GenericMachineBlock extends GenericEntityBlockWaterloggable {
@@ -34,7 +35,7 @@ public class GenericMachineBlock extends GenericEntityBlockWaterloggable {
     public static HashMap<BlockPos, LivingEntity> IPLAYERSTORABLE_MAP = new HashMap<>();
 
     public GenericMachineBlock(BlockEntitySupplier<BlockEntity> blockEntitySupplier, VoxelShapeProvider provider) {
-        super(Blocks.IRON_BLOCK.properties().strength(3.5F).sound(SoundType.METAL).noOcclusion().requiresCorrectToolForDrops());
+        super(VoltaicMaterials.metal().strength(3.5F).sound(SoundType.METAL).noOcclusion().requiresCorrectToolForDrops());
         registerDefaultState(stateDefinition.any().setValue(VoltaicBlockStates.FACING, Direction.NORTH));
         this.blockEntitySupplier = blockEntitySupplier;
         this.shapeProvider = provider;


### PR DESCRIPTION
When installed alongside Bad Packets, CraftedCore, and Create, any block that is set up in its registration using aFullCopy(Blocks.IRON_BLOCK) definition from any other mod is unable to be used as a texture for a Framed Block from the Framed Blocks mod if Voltaic or any of the other mods are installed. It also seems to affect glass and TNT.

I have fixed this by changing the super(Blocks.IRON_BLOCK) as well as the GLASS, TNT, and WHITE_WOOL entries to use the VoltaicMaterials.materialName() methods instead. This fixes the issue. It doesn't look like Modular Forcefields uses the super(Blocks.NAME) anywhere so I have not submitted a fix for it.